### PR TITLE
Adding labels to notes 

### DIFF
--- a/keepsake-app/db.json
+++ b/keepsake-app/db.json
@@ -19,11 +19,6 @@
       "id": "bd3d",
       "username": "Example",
       "password": "Example"
-    },
-    {
-      "id": "dc4a",
-      "username": "newperson",
-      "password": "password"
     }
   ],
   "notes": [
@@ -32,7 +27,6 @@
       "title": "Groceries",
       "content": ["apples", "eggs", "pasta"],
       "category": "shopping list",
-      "labels": [1],
       "isChecklist": true,
       "id": "0202"
     },
@@ -41,7 +35,6 @@
       "title": "Meeting Notes",
       "content": "Discuss marketing strategy and finalise budget allocations.",
       "category": "work",
-      "labels": [2, 3],
       "isChecklist": false,
       "id": "5fef"
     },
@@ -50,7 +43,6 @@
       "title": "Home Repairs",
       "content": ["Fix leaky tap", "Paint living room", "Replace broken tile"],
       "category": "household",
-      "labels": [4],
       "isChecklist": true,
       "id": "51e4"
     },
@@ -59,7 +51,6 @@
       "title": "Book Recommendations",
       "content": "Check out 'Atomic Habits' and 'Deep Work' for productivity tips.",
       "category": "personal growth",
-      "labels": [5, 6],
       "isChecklist": false,
       "id": "bf40"
     },
@@ -68,7 +59,6 @@
       "title": "Weekend Plans",
       "content": ["Hiking trip", "Try new sushi place", "Movie night"],
       "category": "leisure",
-      "labels": [7],
       "isChecklist": true,
       "id": "b4f8"
     },
@@ -77,98 +67,58 @@
       "title": "Project Ideas",
       "content": "Brainstorm app ideas for personal finance tracking.",
       "category": "work",
-      "labels": [8],
       "isChecklist": false,
       "id": "8e94"
-    },
-    {
-      "id": "5c51",
-      "userID": 2,
-      "title": "Howdy",
-      "content": "is label linking",
-      "category": "note",
-      "isChecklist": false
-    },
-    {
-      "id": "628d",
-      "title": "will the labels appear",
-      "content": "labels - shopping",
-      "category": "note",
-      "isChecklist": false
-    },
-    {
-      "id": "6a36",
-      "userID": "d5c5",
-      "title": "label should appear",
-      "content": "have updated getUserID to get id not userId",
-      "category": "note",
-      "isChecklist": false
-    },
-    {
-      "id": "5c51",
-      "userID": 2,
-      "title": "Howdy",
-      "content": "is label linking",
-      "category": "note",
-      "isChecklist": false
     }
   ],
   "labels": [
     {
-      "labelID": 1,
-      "userID": 1,
+      "userIDs": ["dc4a"],
+      "noteIDs": ["0202"],
       "labelName": "Shopping",
       "id": "8526"
     },
     {
-      "labelID": 2,
-      "userID": 1,
+      "userIDs": ["feb6"],
+      "noteIDs": ["0202"],
       "labelName": "Work",
       "id": "89f4"
     },
     {
-      "labelID": 3,
-      "userID": 1,
+      "userIDs": ["feb6"],
+      "noteIDs": [""],
       "labelName": "Budgeting",
       "id": "bcff"
     },
     {
-      "labelID": 4,
-      "userID": 2,
+      "userIDs": ["feb6"],
+      "noteIDs": [""],
       "labelName": "Household",
       "id": "70d6"
     },
     {
-      "labelID": 5,
-      "userID": 2,
+      "userIDs": ["dc4a"],
+      "noteIDs": ["5fef"],
       "labelName": "Books",
       "id": "e7c6"
     },
     {
-      "labelID": 6,
-      "userID": 2,
+      "userIDs": ["dc4a", "feb6"],
+      "noteIDs": ["5fef"],
       "labelName": "Productivity",
       "id": "1da0"
     },
     {
-      "labelID": 7,
-      "userID": 3,
+      "userIDs": [],
+      "noteIDs": [""],
       "labelName": "Leisure",
-      "id": "6b14",
-      "noteID": ["5c51"]
+      "id": "6b14"
     },
     {
-      "labelID": 8,
-      "userID": 3,
+      "userIDs": [],
+      "noteIDs": [""],
       "labelName": "Finance",
-      "id": "9adb",
-      "noteID": ["5c51"]
-    },
-    {
-      "id": "3d3a",
-      "userID": 2,
-      "labelName": "Cowboys",
-      "noteID": ["5c51"]
+      "id": "8bbe"
     }
   ]
 }

--- a/keepsake-app/db.json
+++ b/keepsake-app/db.json
@@ -89,6 +89,78 @@
       "content": "",
       "category": "note",
       "isChecklist": false
+    },
+    {
+      "id": "ac2b",
+      "userID": "d5c5",
+      "title": "check notes",
+      "content": "do they rerender",
+      "category": "note",
+      "isChecklist": false
+    },
+    {
+      "id": "fd14",
+      "userID": "d5c5",
+      "title": "rerender notes",
+      "content": "on creation note appears",
+      "category": "note",
+      "isChecklist": false
+    },
+    {
+      "id": "dd22",
+      "userID": "d5c5",
+      "title": "checking labels render",
+      "content": "123",
+      "category": "note",
+      "isChecklist": false
+    },
+    {
+      "id": "2a2f",
+      "userID": null,
+      "title": "hello",
+      "content": "adding note with labels",
+      "category": "note",
+      "isChecklist": false
+    },
+    {
+      "id": "d3e6",
+      "userID": "d5c5",
+      "title": "checking note render",
+      "content": "do they rerender",
+      "category": "note",
+      "isChecklist": false
+    },
+    {
+      "id": "79bc",
+      "userID": "d5c5",
+      "title": "123",
+      "content": "abcdef",
+      "category": "note",
+      "isChecklist": false
+    },
+    {
+      "id": "8603",
+      "userID": "d5c5",
+      "title": "hi",
+      "content": "is it working?",
+      "category": "note",
+      "isChecklist": false
+    },
+    {
+      "id": "9f4d",
+      "userID": "d5c5",
+      "title": "hi",
+      "content": "looking good",
+      "category": "note",
+      "isChecklist": false
+    },
+    {
+      "id": "3eb6",
+      "userID": "d5c5",
+      "title": "Labels appear",
+      "content": "should be seeing happy and birthday",
+      "category": "note",
+      "isChecklist": false
     }
   ],
   "labels": [
@@ -97,7 +169,8 @@
         "d5c5"
       ],
       "noteIDs": [
-        "0202"
+        "0202",
+        "fd14"
       ],
       "labelName": "Shopping",
       "id": "8526"
@@ -137,7 +210,8 @@
         "d5c5"
       ],
       "noteIDs": [
-        "5fef"
+        "5fef",
+        "dd22"
       ],
       "labelName": "Books",
       "id": "e7c6"
@@ -148,7 +222,9 @@
         "feb6"
       ],
       "noteIDs": [
-        "5fef"
+        "5fef",
+        "ac2b",
+        "fd14"
       ],
       "labelName": "Productivity",
       "id": "1da0"
@@ -175,10 +251,34 @@
       "labelName": "Happy",
       "noteIDs": [
         "a2fd",
-        "c567"
+        "c567",
+        "dd22",
+        "3eb6"
       ],
       "userIDs": [
         "d5c5"
+      ]
+    },
+    {
+      "id": "98fe",
+      "userID": "d5c5",
+      "labelName": "lol",
+      "noteIDs": [
+        "79bc",
+        "9f4d"
+      ],
+      "userIDs": [
+        "d5c5"
+      ]
+    },
+    {
+      "id": "dad6",
+      "userIDs": [
+        "d5c5"
+      ],
+      "labelName": "Birthday",
+      "noteIDs": [
+        "3eb6"
       ]
     }
   ]

--- a/keepsake-app/db.json
+++ b/keepsake-app/db.json
@@ -30,7 +30,11 @@
     {
       "userID": "bd3d",
       "title": "Groceries",
-      "content": ["apples", "eggs", "pasta"],
+      "content": [
+        "apples",
+        "eggs",
+        "pasta"
+      ],
       "category": "shopping list",
       "isChecklist": true,
       "id": "0202"
@@ -46,7 +50,11 @@
     {
       "userID": "feb6",
       "title": "Home Repairs",
-      "content": ["Fix leaky tap", "Paint living room", "Replace broken tile"],
+      "content": [
+        "Fix leaky tap",
+        "Paint living room",
+        "Replace broken tile"
+      ],
       "category": "household",
       "isChecklist": true,
       "id": "51e4"
@@ -62,7 +70,11 @@
     {
       "userID": "feb6",
       "title": "Weekend Plans",
-      "content": ["Hiking trip", "Try new sushi place", "Movie night"],
+      "content": [
+        "Hiking trip",
+        "Try new sushi place",
+        "Movie night"
+      ],
       "category": "leisure",
       "isChecklist": true,
       "id": "b4f8"
@@ -82,56 +94,109 @@
       "content": "is label linking",
       "category": "note",
       "isChecklist": false
+    },
+    {
+      "id": "628d",
+      "title": "will the labels appear",
+      "content": "labels - shopping",
+      "category": "note",
+      "isChecklist": false
+    },
+    {
+      "id": "6a36",
+      "userID": "d5c5",
+      "title": "label should appear",
+      "content": "have updated getUserID to get id not userId",
+      "category": "note",
+      "isChecklist": false
     }
   ],
   "labels": [
     {
-      "userIDs": ["dc4a"],
-      "noteIDs": ["0202"],
+      "userIDs": [
+        "dc4a"
+      ],
+      "noteIDs": [
+        "0202"
+      ],
       "labelName": "Shopping",
       "id": "8526"
     },
     {
-      "userIDs": ["feb6"],
-      "noteIDs": ["0202"],
+      "userIDs": [
+        "feb6"
+      ],
+      "noteIDs": [
+        "0202"
+      ],
       "labelName": "Work",
       "id": "89f4"
     },
     {
-      "userIDs": ["feb6"],
-      "noteIDs": [""],
+      "userIDs": [
+        "feb6"
+      ],
+      "noteIDs": [
+        ""
+      ],
       "labelName": "Budgeting",
       "id": "bcff"
     },
     {
-      "userIDs": ["feb6"],
-      "noteIDs": [""],
+      "userIDs": [
+        "feb6"
+      ],
+      "noteIDs": [
+        ""
+      ],
       "labelName": "Household",
       "id": "70d6"
     },
     {
-      "userIDs": ["dc4a"],
-      "noteIDs": [""],
+      "userIDs": [
+        "dc4a"
+      ],
+      "noteIDs": [
+        ""
+      ],
       "labelName": "Books",
       "id": "e7c6"
     },
     {
-      "userIDs": ["dc4a", "feb6"],
-      "noteIDs": [""],
+      "userIDs": [
+        "dc4a",
+        "feb6"
+      ],
+      "noteIDs": [
+        ""
+      ],
       "labelName": "Productivity",
       "id": "1da0"
     },
     {
       "userIDs": [],
-      "noteIDs": [""],
+      "noteIDs": [
+        ""
+      ],
       "labelName": "Leisure",
       "id": "6b14"
     },
     {
       "userIDs": [],
-      "noteIDs": [""],
+      "noteIDs": [
+        "",
+        "6a36"
+      ],
       "labelName": "Finance",
       "id": "9adb"
+    },
+    {
+      "id": "5e55",
+      "userID": "d5c5",
+      "labelName": "Success",
+      "noteIDs": [
+        "6a36"
+      ]
     }
   ]
 }

--- a/keepsake-app/db.json
+++ b/keepsake-app/db.json
@@ -30,11 +30,7 @@
     {
       "userID": "bd3d",
       "title": "Groceries",
-      "content": [
-        "apples",
-        "eggs",
-        "pasta"
-      ],
+      "content": ["apples", "eggs", "pasta"],
       "category": "shopping list",
       "isChecklist": true,
       "id": "0202"
@@ -50,11 +46,7 @@
     {
       "userID": "feb6",
       "title": "Home Repairs",
-      "content": [
-        "Fix leaky tap",
-        "Paint living room",
-        "Replace broken tile"
-      ],
+      "content": ["Fix leaky tap", "Paint living room", "Replace broken tile"],
       "category": "household",
       "isChecklist": true,
       "id": "51e4"
@@ -70,11 +62,7 @@
     {
       "userID": "feb6",
       "title": "Weekend Plans",
-      "content": [
-        "Hiking trip",
-        "Try new sushi place",
-        "Movie night"
-      ],
+      "content": ["Hiking trip", "Try new sushi place", "Movie night"],
       "category": "leisure",
       "isChecklist": true,
       "id": "b4f8"
@@ -86,83 +74,62 @@
       "category": "work",
       "isChecklist": false,
       "id": "8e94"
+    },
+    {
+      "id": "5c51",
+      "userID": 2,
+      "title": "Howdy",
+      "content": "is label linking",
+      "category": "note",
+      "isChecklist": false
     }
   ],
   "labels": [
     {
-      "userIDs": [
-        "dc4a"
-      ],
-      "noteIDs": [
-        "0202"
-      ],
+      "userIDs": ["dc4a"],
+      "noteIDs": ["0202"],
       "labelName": "Shopping",
       "id": "8526"
     },
     {
-      "userIDs": [
-        "feb6"
-      ],
-      "noteIDs": [
-        "0202"
-      ],
+      "userIDs": ["feb6"],
+      "noteIDs": ["0202"],
       "labelName": "Work",
       "id": "89f4"
     },
     {
-      "userIDs": [
-        "feb6"
-      ],
-      "noteIDs": [
-        ""
-      ],
+      "userIDs": ["feb6"],
+      "noteIDs": [""],
       "labelName": "Budgeting",
       "id": "bcff"
     },
     {
-      "userIDs": [
-        "feb6"
-      ],
-      "noteIDs": [
-        ""
-      ],
+      "userIDs": ["feb6"],
+      "noteIDs": [""],
       "labelName": "Household",
       "id": "70d6"
     },
     {
-      "userIDs": [
-        "dc4a"
-      ],
-      "noteIDs": [
-        ""
-      ],
+      "userIDs": ["dc4a"],
+      "noteIDs": [""],
       "labelName": "Books",
       "id": "e7c6"
     },
     {
-      "userIDs": [
-        "dc4a",
-        "feb6"
-      ],
-      "noteIDs": [
-        ""
-      ],
+      "userIDs": ["dc4a", "feb6"],
+      "noteIDs": [""],
       "labelName": "Productivity",
       "id": "1da0"
     },
     {
       "userIDs": [],
-      "noteIDs": [
-        ""
-      ],
+      "noteIDs": [""],
       "labelName": "Leisure",
       "id": "6b14"
     },
     {
       "userIDs": [],
-      "noteIDs": [
-        ""
-      ],
+      "noteIDs": [""],
       "labelName": "Finance",
       "id": "9adb"
     }

--- a/keepsake-app/db.json
+++ b/keepsake-app/db.json
@@ -73,7 +73,7 @@
   ],
   "labels": [
     {
-      "userIDs": ["dc4a"],
+      "userIDs": ["d5c5"],
       "noteIDs": ["0202"],
       "labelName": "Shopping",
       "id": "8526"
@@ -97,13 +97,13 @@
       "id": "70d6"
     },
     {
-      "userIDs": ["dc4a"],
+      "userIDs": ["d5c5"],
       "noteIDs": ["5fef"],
       "labelName": "Books",
       "id": "e7c6"
     },
     {
-      "userIDs": ["dc4a", "feb6"],
+      "userIDs": ["d5c5", "feb6"],
       "noteIDs": ["5fef"],
       "labelName": "Productivity",
       "id": "1da0"
@@ -119,6 +119,13 @@
       "noteIDs": [""],
       "labelName": "Finance",
       "id": "8bbe"
+    },
+    {
+      "id": "3bfb",
+      "userID": "d5c5",
+      "labelName": "Happy",
+      "noteIDs": ["a2fd"],
+      "userIDs": ["d5c5"]
     }
   ]
 }

--- a/keepsake-app/db.json
+++ b/keepsake-app/db.json
@@ -25,7 +25,11 @@
     {
       "userID": "bd3d",
       "title": "Groceries",
-      "content": ["apples", "eggs", "pasta"],
+      "content": [
+        "apples",
+        "eggs",
+        "pasta"
+      ],
       "category": "shopping list",
       "isChecklist": true,
       "id": "0202"
@@ -41,7 +45,11 @@
     {
       "userID": "feb6",
       "title": "Home Repairs",
-      "content": ["Fix leaky tap", "Paint living room", "Replace broken tile"],
+      "content": [
+        "Fix leaky tap",
+        "Paint living room",
+        "Replace broken tile"
+      ],
       "category": "household",
       "isChecklist": true,
       "id": "51e4"
@@ -57,7 +65,11 @@
     {
       "userID": "feb6",
       "title": "Weekend Plans",
-      "content": ["Hiking trip", "Try new sushi place", "Movie night"],
+      "content": [
+        "Hiking trip",
+        "Try new sushi place",
+        "Movie night"
+      ],
       "category": "leisure",
       "isChecklist": true,
       "id": "b4f8"
@@ -69,54 +81,91 @@
       "category": "work",
       "isChecklist": false,
       "id": "8e94"
+    },
+    {
+      "id": "c567",
+      "userID": "d5c5",
+      "title": "Hello",
+      "content": "",
+      "category": "note",
+      "isChecklist": false
     }
   ],
   "labels": [
     {
-      "userIDs": ["d5c5"],
-      "noteIDs": ["0202"],
+      "userIDs": [
+        "d5c5"
+      ],
+      "noteIDs": [
+        "0202"
+      ],
       "labelName": "Shopping",
       "id": "8526"
     },
     {
-      "userIDs": ["feb6"],
-      "noteIDs": ["0202"],
+      "userIDs": [
+        "feb6"
+      ],
+      "noteIDs": [
+        "0202"
+      ],
       "labelName": "Work",
       "id": "89f4"
     },
     {
-      "userIDs": ["feb6"],
-      "noteIDs": [""],
+      "userIDs": [
+        "feb6"
+      ],
+      "noteIDs": [
+        ""
+      ],
       "labelName": "Budgeting",
       "id": "bcff"
     },
     {
-      "userIDs": ["feb6"],
-      "noteIDs": [""],
+      "userIDs": [
+        "feb6"
+      ],
+      "noteIDs": [
+        ""
+      ],
       "labelName": "Household",
       "id": "70d6"
     },
     {
-      "userIDs": ["d5c5"],
-      "noteIDs": ["5fef"],
+      "userIDs": [
+        "d5c5"
+      ],
+      "noteIDs": [
+        "5fef"
+      ],
       "labelName": "Books",
       "id": "e7c6"
     },
     {
-      "userIDs": ["d5c5", "feb6"],
-      "noteIDs": ["5fef"],
+      "userIDs": [
+        "d5c5",
+        "feb6"
+      ],
+      "noteIDs": [
+        "5fef"
+      ],
       "labelName": "Productivity",
       "id": "1da0"
     },
     {
       "userIDs": [],
-      "noteIDs": [""],
+      "noteIDs": [
+        ""
+      ],
       "labelName": "Leisure",
       "id": "6b14"
     },
     {
       "userIDs": [],
-      "noteIDs": [""],
+      "noteIDs": [
+        ""
+      ],
       "labelName": "Finance",
       "id": "8bbe"
     },
@@ -124,8 +173,13 @@
       "id": "3bfb",
       "userID": "d5c5",
       "labelName": "Happy",
-      "noteIDs": ["a2fd"],
-      "userIDs": ["d5c5"]
+      "noteIDs": [
+        "a2fd",
+        "c567"
+      ],
+      "userIDs": [
+        "d5c5"
+      ]
     }
   ]
 }

--- a/keepsake-app/src/components/CustomLabelInput.tsx
+++ b/keepsake-app/src/components/CustomLabelInput.tsx
@@ -18,6 +18,8 @@ export const CustomLabelInput = ({
 
   useEffect(() => {
     const fetchLabels = async () => {
+      const userID = await getUserID(username);
+      console.log("Fetching labels with userID:", userID);
       try {
         const res = await fetch(`http://localhost:3000/labels`);
         if (!res.ok) throw new Error("Failed to fetch labels");
@@ -43,14 +45,13 @@ export const CustomLabelInput = ({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             userID: userID,
-            // noteID:, how to get this?
             labelName: inputValue,
           }),
         });
 
         if (!res.ok) throw new Error("Failed to post label");
         const data = await res.json();
-        setLabels((prev: label[]) => [...prev, data]); //our post request only returns the new label not the list of labels
+        setLabels((prev: label[]) => [...prev, data]);
         setInputValue("");
       } catch (err) {
         console.error("Error posting label:", err);

--- a/keepsake-app/src/components/CustomLabelInput.tsx
+++ b/keepsake-app/src/components/CustomLabelInput.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import { useState, useEffect } from "react";
-import { label } from "./Gallery.tsx";
+import { LabelObj } from "./Note.tsx";
 
 interface CustomLabelInputProps {
-  setNoteLabels: React.Dispatch<React.SetStateAction<label[]>>;
+  setNoteLabels: React.Dispatch<React.SetStateAction<LabelObj[]>>;
   username: string;
   getUserID(username: string): Promise<any>;
 }
@@ -14,18 +14,18 @@ export const CustomLabelInput = ({
   getUserID,
 }: CustomLabelInputProps) => {
   const [inputValue, setInputValue] = useState("");
-  const [labels, setLabels] = useState<label[]>([]);
+  const [labels, setLabels] = useState<LabelObj[]>([]);
 
   useEffect(() => {
     const fetchLabels = async () => {
       const userID = await getUserID(username);
-      console.log("Fetching labels with userID:", userID);
       try {
         const res = await fetch(`http://localhost:3000/labels`);
         if (!res.ok) throw new Error("Failed to fetch labels");
-        const data = await res.json(); //must filter so that only labels with label.userIDs.includes(userID)
-        const userLabels = data.filter((label: any) =>
-          label.userIDs?.includes(userID)
+        const data = await res.json();
+        console.log(data);
+        const userLabels = data.filter((label: LabelObj) =>
+          label.userIDs.includes(userID)
         );
         setLabels(userLabels);
       } catch (err) {
@@ -40,21 +40,21 @@ export const CustomLabelInput = ({
     event: React.KeyboardEvent<HTMLInputElement>
   ) => {
     const userID = await getUserID(username);
-    console.log("Posting label with userID:", userID);
     if (event.key === "Enter" && inputValue.trim() !== "") {
       try {
         const res = await fetch(`http://localhost:3000/labels`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
-            userID: userID,
+            userIDs: [userID],
             labelName: inputValue,
+            noteIDs: [],
           }),
         });
 
         if (!res.ok) throw new Error("Failed to post label");
         const data = await res.json();
-        setLabels((prev: label[]) => [...prev, data]);
+        setLabels((prev: LabelObj[]) => [...prev, data]);
         setInputValue("");
       } catch (err) {
         console.error("Error posting label:", err);

--- a/keepsake-app/src/components/CustomLabelInput.tsx
+++ b/keepsake-app/src/components/CustomLabelInput.tsx
@@ -23,15 +23,18 @@ export const CustomLabelInput = ({
       try {
         const res = await fetch(`http://localhost:3000/labels`);
         if (!res.ok) throw new Error("Failed to fetch labels");
-        const data = await res.json();
-        setLabels(data);
+        const data = await res.json(); //must filter so that only labels with label.userIDs.includes(userID)
+        const userLabels = data.filter((label: any) =>
+          label.userIDs?.includes(userID)
+        );
+        setLabels(userLabels);
       } catch (err) {
         console.error("Error fetching labels:", err);
       }
     };
 
     fetchLabels();
-  }, []);
+  }, [username]);
 
   const handleKeyDown = async (
     event: React.KeyboardEvent<HTMLInputElement>

--- a/keepsake-app/src/components/Gallery.tsx
+++ b/keepsake-app/src/components/Gallery.tsx
@@ -48,6 +48,7 @@ export default function Gallery({
   const [content, setContent] = useState("");
   const [labels, setLabels] = useState<label[]>([]);
   const [notes, setNotes] = useState([]);
+  const [isAddingLabel, setIsAddingLabel] = useState(false);
 
   async function getNotes() {
     let response = await fetch(`http://localhost:3000/notes`);
@@ -131,6 +132,14 @@ export default function Gallery({
     }
   }
 
+  function handleAddLabelClick() {
+    setIsAddingLabel(true);
+  }
+
+  function handleConfirmLabelClick() {
+    setIsAddingLabel(false);
+  }
+
   return (
     <div className="gallery">
       <div className="add-new-note">
@@ -148,12 +157,25 @@ export default function Gallery({
               placeholder="Take a note..."
               onChange={(e) => setContent(e.target.value)}
             ></textarea>
-
-            <CustomLabelInput
-              setNoteLabels={setLabels}
-              username={username}
-              getUserID={getUserID}
-            />
+            {isAddingLabel ? (
+              <>
+                <CustomLabelInput
+                  setNoteLabels={setLabels}
+                  username={username}
+                  getUserID={getUserID}
+                />{" "}
+                <button
+                  className="add-label-btn"
+                  onClick={handleConfirmLabelClick}
+                >
+                  Confirm labels
+                </button>
+              </>
+            ) : (
+              <button className="add-label-btn" onClick={handleAddLabelClick}>
+                Add labels
+              </button>
+            )}
 
             <button onClick={handleAddNoteClick}>Submit</button>
           </div>

--- a/keepsake-app/src/components/Gallery.tsx
+++ b/keepsake-app/src/components/Gallery.tsx
@@ -84,6 +84,11 @@ export default function Gallery({
         const existingLabel = await res.json();
 
         const currentNoteIDs: string[] = existingLabel.noteIDs || [];
+        let currentUserIDs: string[] = existingLabel.userIDs || []; //might need to adjust this
+
+        if (!currentUserIDs.includes(userID)) {
+          currentUserIDs = [...currentUserIDs, userID];
+        }
 
         if (!currentNoteIDs.includes(noteID)) {
           const updatedNoteIDs = [...currentNoteIDs, noteID];
@@ -95,6 +100,7 @@ export default function Gallery({
             },
             body: JSON.stringify({
               noteIDs: updatedNoteIDs,
+              userIDs: currentUserIDs,
             }),
           });
         }

--- a/keepsake-app/src/components/Gallery.tsx
+++ b/keepsake-app/src/components/Gallery.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import "./Gallery.css";
 import Note from "./Note";
 import { CustomLabelInput } from "./CustomLabelInput";
+import { LabelObj } from "./Note.tsx";
 
 interface NoteObj {
   id: string;
@@ -15,13 +16,6 @@ interface GalleryProps {
   username: string;
   isAddingNote: boolean;
   setIsAddingNote: React.Dispatch<React.SetStateAction<boolean>>;
-}
-
-export interface label {
-  id: string;
-  userIDs: number[];
-  labelName: string;
-  noteIDs: string[];
 }
 
 async function getUserID(username: string) {
@@ -46,8 +40,8 @@ export default function Gallery({
 }: GalleryProps) {
   const [title, setTitle] = useState("");
   const [content, setContent] = useState("");
-  const [labels, setLabels] = useState<label[]>([]);
-  const [notes, setNotes] = useState([]);
+  const [labels, setLabels] = useState<LabelObj[]>([]);
+  const [notes, setNotes] = useState<NoteObj[]>([]);
   const [isAddingLabel, setIsAddingLabel] = useState(false);
 
   async function getNotes() {
@@ -76,8 +70,11 @@ export default function Gallery({
         isChecklist: false,
       }),
     });
+    const new_note = await response.json();
+    console.log(new_note);
+    setNotes([...notes, new_note]);
 
-    const noteID = await getLatestNoteID(userID);
+    const noteID = new_note.id;
 
     if (noteID !== null) {
       for (const label of labels) {
@@ -110,26 +107,6 @@ export default function Gallery({
     setIsAddingNote(false);
     setTitle("");
     setContent("");
-  }
-
-  async function getLatestNoteID(userID: string): Promise<string | null> {
-    try {
-      if (!userID) return null;
-
-      const res = await fetch("http://localhost:3000/notes");
-      const notes = await res.json();
-
-      const userNotes = notes.filter((note: any) => note.userID === userID);
-
-      if (userNotes.length === 0) return null;
-
-      const latestNote = userNotes[userNotes.length - 1];
-
-      return latestNote.id;
-    } catch (err) {
-      console.error("Error fetching latest note:", err);
-      return null;
-    }
   }
 
   function handleAddLabelClick() {

--- a/keepsake-app/src/components/Gallery.tsx
+++ b/keepsake-app/src/components/Gallery.tsx
@@ -19,9 +19,9 @@ interface GalleryProps {
 
 export interface label {
   id: string;
-  userID: number;
+  userIDs: number[];
   labelName: string;
-  noteID: string[];
+  noteIDs: string[];
 }
 
 async function getUserID(username: string) {
@@ -32,7 +32,7 @@ async function getUserID(username: string) {
     const user = users.find(
       (user: { username: string }) => user.username === username
     );
-    return user ? user.userID : null;
+    return user ? user.id : null;
   } catch (error) {
     console.error("Error fetching users:", error);
     return null;
@@ -83,7 +83,7 @@ export default function Gallery({
         const res = await fetch(`http://localhost:3000/labels/${label.id}`);
         const existingLabel = await res.json();
 
-        const currentNoteIDs: string[] = existingLabel.noteID || [];
+        const currentNoteIDs: string[] = existingLabel.noteIDs || [];
 
         if (!currentNoteIDs.includes(noteID)) {
           const updatedNoteIDs = [...currentNoteIDs, noteID];
@@ -94,7 +94,7 @@ export default function Gallery({
               "Content-Type": "application/json",
             },
             body: JSON.stringify({
-              noteID: updatedNoteIDs,
+              noteIDs: updatedNoteIDs,
             }),
           });
         }

--- a/keepsake-app/src/components/Note.tsx
+++ b/keepsake-app/src/components/Note.tsx
@@ -9,7 +9,7 @@ interface NoteProp {
   labels: number[];
 }
 
-interface LabelObj {
+export interface LabelObj {
   id: string;
   userIDs: string[];
   noteIDs: string[];


### PR DESCRIPTION
Current functionality
- when adding a note there is a 'add labels' button
- when clicked dropdown appears with current users available labels and custom label input section
- there is also a confirm labels button which hides this section again
- As expected db.json is updated with the new labels created - these have a userIDs list and noteIDs list 

Still to do
- implement 'submit custom label' button for clarity 
